### PR TITLE
Update pawn.json

### DIFF
--- a/pawn.json
+++ b/pawn.json
@@ -4,7 +4,17 @@
 	"repo": "SAMPSON",
 	"entry": "test.pwn",
 	"output": "test.amx",
-	"dependencies": [
-		"sampctl/samp-stdlib"
+	"dependencies": ["sampctl/samp-stdlib"],
+	"resources": [
+		{
+			"name": "SAMPSON.dll",
+			"platform": "windows",
+			"archive": false
+		},
+		{
+			"name": "SAMPSON.so",
+			"platform": "linux",
+			"archive": false
+		}
 	]
 }


### PR DESCRIPTION
sampctl now supports non-archive plugin files (everyone else seems to zip/tar plugin binaries apart from my releases and SAMPSON...)